### PR TITLE
Fix duplicate yfinance data and runtime robustness

### DIFF
--- a/src/broker/kite.py
+++ b/src/broker/kite.py
@@ -1,14 +1,24 @@
 from dataclasses import dataclass
+from typing import Optional
+
+
 @dataclass
 class KiteAuth:
     api_key: str
     api_secret: str
     access_token: str
+
+
 class KiteBroker:
-    def init(self, auth: KiteAuth):
+    def __init__(self, auth: Optional[KiteAuth] = None):
+        self.auth: Optional[KiteAuth] = auth
+
+    def set_auth(self, auth: KiteAuth) -> None:
         self.auth = auth
 
     def is_ready(self) -> bool:
+        if not self.auth:
+            return False
         return all([self.auth.api_key, self.auth.api_secret, self.auth.access_token])
 
     def place_order(self, symbol: str, side: str, qty: int, order_type: str = "MARKET"):

--- a/src/data/yf_data.py
+++ b/src/data/yf_data.py
@@ -41,18 +41,31 @@ def _only_market_hours(df: pd.DataFrame) -> pd.DataFrame:
     return df.between_time(cfg.market.start, cfg.market.end, inclusive="both")
 
 def fetch_15m_history(symbol: str, lookback_bars: int | None = None) -> pd.DataFrame:
+    """Fetch 15 minute history for a single symbol.
+
+    Using ``Ticker.history`` avoids a yfinance quirk where ``download`` caches the
+    previous response when multiple requests are issued in quick succession. That
+    manifested as every symbol receiving the exact same raw data in the screener.
+    """
+
     lookback_bars = lookback_bars or cfg.screener.lookback_bars
-    df = yf.download(
-        symbol,
-        interval="15m",
-        period="60d",
-        progress=False,
-        auto_adjust=False,
-        group_by="column",     # ← prevents per-ticker grouping
-        threads=False          # sanity; single symbol anyway
-    )
+    try:
+        ticker = yf.Ticker(symbol)
+        df = ticker.history(
+            interval="15m",
+            period="60d",
+            auto_adjust=False,
+            actions=False,
+        )
+    except Exception:
+        return pd.DataFrame()
     if df is None or df.empty:
         return pd.DataFrame()
+    df = df.copy()
+    # Drop columns we never use (splits/dividends)
+    drop_cols = [c for c in ["Dividends", "Stock Splits", "Capital Gains"] if c in df.columns]
+    if drop_cols:
+        df.drop(columns=drop_cols, inplace=True)
     df = _drop_ticker_level(df)
     df = _to_ist_index(df)
     df = _only_market_hours(df)

--- a/src/exec/paper_trader.py
+++ b/src/exec/paper_trader.py
@@ -136,3 +136,14 @@ def main():
         try:
             run_once()
             time.sleep(SLEEP_SECONDS)
+        except KeyboardInterrupt:
+            print("\nPaper trader stopped by user.")
+            break
+        except Exception as exc:
+            # Don't crash the loop on transient API/IO errors
+            print(f"[{utcnow_iso()}] ERROR: {exc}")
+            time.sleep(SLEEP_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch 15m history fetch to yfinance Ticker.history to avoid cached responses across symbols
- make the paper trader loop resilient to errors and properly handle shutdown
- fix the Kite broker helper to expose a usable constructor and optional auth assignment

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e197ddda348324bfaf9cdc81f90fea