### PR TITLE
Include OHLCV columns in step signal debug export

### DIFF
--- a/src/screener.py
+++ b/src/screener.py
@@ -70,7 +70,8 @@ def screen_symbol(sym: str):
     # Dump the signal step (booleans + inputs used to decide)
     if DEBUG_STEPS:
         sig_cols = [
-            "Close", "RSI", "MACD_HIST", "OBV_DELTA", "VO",
+            "Open", "High", "Low", "Close", "Volume",
+            "RSI", "MACD_HIST", "OBV_DELTA", "VO",
             "RSI_CROSS_UP", "MACD_BULL", "OBV_POS", "VO_POS",
             "ENTRY", "RSI_CROSS_DOWN", "EXIT"
         ]


### PR DESCRIPTION
## Summary
- add open, high, low, and volume columns to the step signal debug CSV export so raw price/volume data is available in debug files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21c3ed17c83249c77ceec2e8d89a8